### PR TITLE
fix(demo): load both analysis and generation transducers

### DIFF
--- a/packages/demo/public/english-morphology.html
+++ b/packages/demo/public/english-morphology.html
@@ -272,8 +272,11 @@
     // Load English models
     async function loadEnglish() {
       try {
-        // Use GitHub raw URL directly (JSDelivr npm package not published yet)
-        const githubPackUrl = 'https://raw.githubusercontent.com/willwade/morpho-wasm/main/packages/packs/en-US/v1/generate.hfstol';
+        // Use GitHub raw URLs for analysis and generation transducers
+        const basePackUrl = 'https://raw.githubusercontent.com/willwade/morpho-wasm/main/packages/packs/en-US/v1/';
+        const githubPackUrl = `${basePackUrl}analysis.hfstol?${new URLSearchParams({
+          gen: `${basePackUrl}generate.hfstol`
+        })}`;
         console.log('📦 Loading from GitHub raw URL:', githubPackUrl);
 
         configureMorphHfst({ packUrl: githubPackUrl });


### PR DESCRIPTION
## Summary
- ensure English demo loads analysis + generation HFST files from GitHub raw URLs

## Testing
- `npm test` *(fails: fetch failed for some CDN resources)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2805a52c8327be77e6a33a2ca36f